### PR TITLE
Add filter efficiency to SparmMaker

### DIFF
--- a/interface/SParmMaker.h
+++ b/interface/SParmMaker.h
@@ -35,6 +35,7 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
 
 //
 // class declaration
@@ -47,6 +48,8 @@ public:
 
 private:
     virtual void beginJob() ;
+    virtual void beginLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup&) ;
+    virtual void endLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup&) ;
     virtual void produce(edm::Event&, const edm::EventSetup&);
     virtual void endJob() ;
       
@@ -54,7 +57,8 @@ private:
     edm::EDGetTokenT<LHEEventProduct> sparmToken;
     edm::EDGetTokenT<GenLumiInfoHeader> configToken;
     std::string aliasprefix_;
-  std::vector<std::string> vsparms_;
+    std::vector<std::string> vsparms_;
+    float filtEff;
 };
 
 

--- a/src/SParmMaker.cc
+++ b/src/SParmMaker.cc
@@ -75,6 +75,8 @@ SParmMaker::SParmMaker(const edm::ParameterSet& iConfig) {
   produces<float>                 (branchprefix+"pdfScale"         ).setBranchAlias(aliasprefix_+"_pdfScale"         );
   produces<float>                 (branchprefix+"filterEfficiency" ).setBranchAlias(aliasprefix_+"_filterEfficiency" );
   produces<float>                 (branchprefix+"xsec"             ).setBranchAlias(aliasprefix_+"_xsec"             );
+
+  filtEff = 1.;
  
 }
 
@@ -83,6 +85,17 @@ SParmMaker::~SParmMaker() {}
 //
 // member functions
 //
+
+void SParmMaker::beginLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const& iSetup) {
+
+    edm::Handle<GenFilterInfo> config_handle_filter;  
+    iLumi.getByLabel("genFilterEfficiencyProducer", config_handle_filter);
+    filtEff = config_handle_filter->filterEfficiency();
+
+}
+
+void SParmMaker::endLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const& iSetup) {
+}
 
 // ------------ method called to produce the data  ------------
 void SParmMaker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -129,6 +142,8 @@ void SParmMaker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         }
       }
     }
+
+    *sparm_filterEfficiency = filtEff;
 
     if( sparm_handle.isValid() && !found_sparms ){
         for (std::vector<std::string>::const_iterator it = sparm_handle->comments_begin(); it != sparm_handle->comments_end(); it++) {      

--- a/test/MCProduction2015_FastSim_NoFilter_cfg.py
+++ b/test/MCProduction2015_FastSim_NoFilter_cfg.py
@@ -27,7 +27,7 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 
 # services
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-process.GlobalTag.globaltag = "80X_mcRun2_asymptotic_v12"
+process.GlobalTag.globaltag = "80X_mcRun2_asymptotic_2016_miniAODv2_v0"
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
 process.MessageLogger.cerr.threshold  = ''
 process.MessageLogger.suppressWarning = cms.untracked.vstring('ecalLaserCorrFilter','manystripclus53X','toomanystripclus53X')
@@ -82,13 +82,15 @@ process.hypDilepMaker.LooseLepton_PtCut  = cms.double(10.0)
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(
                                 # 'file:/hadoop/cms/phedex/store/mc/RunIISpring15MiniAODv2/SMS-T1bbbb_mGluino-1000_mLSP-900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/80000/68A49080-8674-E511-8DBF-0025905AF57C.root'
-                                '/store/relval/CMSSW_8_0_5/RelValSusySignalTest2/MINIAODSIM/PUpmx25ns_80X_mcRun2_asymptotic_v12_FastSim-v1/00000/C2155CF4-4B08-E611-A8D8-0025905A60A6.root'
+                                # '/store/relval/CMSSW_8_0_5/RelValSusySignalTest2/MINIAODSIM/PUpmx25ns_80X_mcRun2_asymptotic_v12_FastSim-v1/00000/C2155CF4-4B08-E611-A8D8-0025905A60A6.root'
+                                # '/store/mc/RunIISpring16MiniAODv2/SMS-T2cc_genHT-160_genMET-80_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16Fast_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/60000/8678265E-894C-E611-B8EE-FA163EE0C467.root'
+                                'file:8678265E-894C-E611-B8EE-FA163EE0C467.root' # above file
                             )
 )
 process.source.noEventSort = cms.untracked.bool( True )
 
 #Max Events
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 
 #Branches 
 process.out.outputCommands = cms.untracked.vstring( 'keep *' )
@@ -224,5 +226,5 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 100
 process.eventMaker.isData                        = cms.bool(False)
 #process.luminosityMaker.isData                   = process.eventMaker.isData
 
-# process.sParmMaker.vsparms                       = cms.untracked.vstring("mGluino", "mLSP")
-# process.p.insert( -1, process.sParmMakerSequence )
+process.sParmMaker.vsparms                       = cms.untracked.vstring("mGluino", "mLSP")
+process.p.insert( -1, process.sParmMakerSequence )


### PR DESCRIPTION
Apparently, to access this information, you must do so at the end of lumi blocks, but then how do we fill branches for events before the end of the first block? Use of getByLabel to get filter efficiency for mass points at beginning of lumi block is *not kosher, but works*. See [here](https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3437/1/1.html). A benign exception is printed out due to this at the beginning of each lumi block.

Alternative is to fill a histogram with filter efficiencies at the end of lumi blocks and then handle these in postprocessing, which would require rewriting a lot of the downstream postprocessing/ntuplization scripts.