### PR TITLE
These lines are useless

### DIFF
--- a/interface/SParmMaker.h
+++ b/interface/SParmMaker.h
@@ -56,6 +56,7 @@ private:
     // ----------member data ---------------------------
     edm::EDGetTokenT<LHEEventProduct> sparmToken;
     edm::EDGetTokenT<GenLumiInfoHeader> configToken;
+    edm::EDGetTokenT<GenFilterInfo> configToken_filt;
     std::string aliasprefix_;
     std::vector<std::string> vsparms_;
     float filtEff;

--- a/src/SParmMaker.cc
+++ b/src/SParmMaker.cc
@@ -60,6 +60,7 @@ SParmMaker::SParmMaker(const edm::ParameterSet& iConfig) {
   // parameters from configuration
   sparmToken = consumes<LHEEventProduct>(iConfig.getParameter<edm::InputTag>("sparm_inputTag"));
   configToken = consumes<GenLumiInfoHeader, edm::InLumi>(iConfig.getParameter<edm::InputTag>("config_inputTag"));
+  configToken_filt = consumes<GenFilterInfo, edm::InLumi>(edm::InputTag("genFilterEfficiencyProducer"));
 
   // sparm names from configuration
   vsparms_ = iConfig.getUntrackedParameter<std::vector<std::string> >("vsparms");


### PR DESCRIPTION
but they are needed to tell cmssw to consume the GenFilterInfo, otherwise we get insane errors.