### PR TITLE
Add LHE handler

### DIFF
--- a/BuildFile.xml
+++ b/BuildFile.xml
@@ -28,8 +28,15 @@
 <use   name="EgammaAnalysis/ElectronTools"/>
 <use   name="PhysicsTools/NanoAOD"/>
 <use   name="NNKit/FatJetNN"/>
+<use   name="ZZMatrixElement/MELA"/>
+<use   name="MelaAnalytics/EventContainer"/>
+<use   name="CommonLHETools/LHEHandler"/>
 <use   name="root"/>
 <use   name="clhep"/>
+
+<Flags CPPDEFINES="CMSSW_VERSION=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_//g -e s/patch\.//)"/>
+<Flags CPPDEFINES="CMSSW_VERSION_MAJOR=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_.*//g)"/>
+<flags CPPFLAGS="-I$(CMSSW_BASE)/src/ZZMatrixElement/MELA/interface/" />
 
 <lib   name="EG"/>
 <flags   EDM_PLUGIN="1"/>

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,23 @@ git clone git@github.com:cmstas/NtupleMaker.git CMS3/NtupleMaker
 cd CMS3/NtupleMaker
 git checkout $CMS3Tag
 source setup/patchesToSource.sh
+
+#######################################
+# No CMSSW packages beyond this point #
+#######################################
+
+# MELA
+git clone git@github.com:cms-analysis/HiggsAnalysis-ZZMatrixElement.git ZZMatrixElement
+(cd ZZMatrixElement; git checkout -b from-v217b1 v2.1.7b1; source setup.sh -j 12;)
+
+# MELA Analytics
+git clone git@github.com:usarica/MelaAnalytics.git
+(cd MelaAnalytics; git checkout -b from-v11 v1.1)
+
+# Common LHE tools
+git clone git@github.com:usarica/CommonLHETools.git
+(cd CommonLHETools; git checkout -b from-v121 v1.2.1)
+
 cd $CMSSW_BASE/src
 scram b -j 25
 cd ..

--- a/interface/GenMaker.h
+++ b/interface/GenMaker.h
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -34,8 +35,10 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
-#include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include "CommonLHETools/LHEHandler/interface/LHEHandler.h" 
+
 
 //
 // class decleration
@@ -53,11 +56,15 @@ private:
      virtual void beginRun(const edm::Run&, const edm::EventSetup&);
 
      // ----------member data ---------------------------
+     const edm::ParameterSet inputPSet;
+
+     int year;
+
      edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken;
      edm::EDGetTokenT<GenEventInfoProduct> genEvtInfoToken;
      edm::EDGetTokenT<pat::PackedGenParticleCollection> packedGenParticlesToken;
      edm::EDGetTokenT<LHEEventProduct> LHEEventInfoToken;
-	 edm::InputTag genRunInfoInputTag_;
+     edm::InputTag genRunInfoInputTag_;
      bool ntupleOnlyStatus3_;
      bool ntupleDaughters_;
      bool ntuplePackedGenParticles_;
@@ -67,6 +74,10 @@ private:
      double inclusiveCrossSectionValue_;
      double exclusiveCrossSectionValue_;
      double kfactorValue_;
+
+     shared_ptr<LHEHandler> lheHandler; // LHEHandler for default PDFs
+     shared_ptr<LHEHandler> lheHandler_NNPDF30_NLO; // LHEHandler for the 2016-like PDFs
+
 };
 
 #endif

--- a/python/genMaker_cfi.py
+++ b/python/genMaker_cfi.py
@@ -7,18 +7,19 @@ if configProcessName.isFastSim: LHEtag = "source"
 
 #genMaker = cms.EDFilter("GenMaker",
 genMaker = cms.EDProducer("GenMaker",
-	aliasPrefix = cms.untracked.string("genps"),
+    year = cms.int32(-1),
+    aliasPrefix = cms.untracked.string("genps"),
     ntupleOnlyStatus3     = cms.bool(False), # just get everything since Pythia8 has weird status codes
     ntupleDaughters       = cms.bool(True),
     genParticlesInputTag  = cms.InputTag("prunedGenParticles" ),
     genEvtInfoInputTag  = cms.InputTag("generator" ),
-    ntuplePackedGenParticles    = cms.bool(False), # default is False                          
+    ntuplePackedGenParticles    = cms.bool(False), # default is False
     packedGenParticlesInputTag  = cms.InputTag("packedGenParticles" ), # Assign Status "1111" to these to avoid duplication. Only save p4, ID, status
     #genRunInfoInputTag    = cms.InputTag("generator"),
     exclusiveCrossSection = cms.untracked.double(0.0),
     inclusiveCrossSection = cms.untracked.double(0.0),
     kfactor               = cms.untracked.double(1.0),
-    LHEInputTag = cms.InputTag( LHEtag ), 
+    LHEInputTag = cms.InputTag( LHEtag ),
 
     #PID of LSP, or MET particles besides nu's (which are always included)
     #For all LM points (msugra), LSP = 1000022. For GMSB, LSP = 1000039


### PR DESCRIPTION
Added default weights + PDF up/dn and alphas(MZ) up/dn as in 2016. genLHE* are always ratios to nominal weight; this is so that you can apply muR/muF variations to either non '2016' and '2016' weights to obtain variations.

Test of speed:
python profiling/print_timing.py logrun_nochange.log
70it [00:00, 1565.43it/s]
Average event rate: 26.4Hz (linear fit to Begin Processing lines)

python profiling/print_timing.py logrun_new.log
91it [00:00, 4462.96it/s]
Average event rate: 27.3Hz (linear fit to Begin Processing lines)

Run new second time:
python profiling/print_timing.py logrun_new.log
91it [00:00, 772.52it/s]
Average event rate: 25.8Hz (linear fit to Begin Processing lines)

Not much effect on speed I suppose.