### PR TITLE
Increment LHEHandle version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ git clone git@github.com:usarica/MelaAnalytics.git
 
 # Common LHE tools
 git clone git@github.com:usarica/CommonLHETools.git
-(cd CommonLHETools; git checkout -b from-v122 v1.2.2)
+(cd CommonLHETools; git checkout -b from-v123 v1.2.3)
 
 cd $CMSSW_BASE/src
 scram b -j 25

--- a/src/GenMaker.cc
+++ b/src/GenMaker.cc
@@ -158,7 +158,7 @@ void GenMaker::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
 
 // ------------ method called to produce the data  ------------
 void GenMaker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  
+
     unique_ptr<vector<int> >                    genps_id              (new vector<int>                   );
     unique_ptr<vector<int> >                    genps_id_mother       (new vector<int>                   );
     unique_ptr<vector<int> >                    genps_id_simplemother (new vector<int>                   );
@@ -315,7 +315,7 @@ void GenMaker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
       if (genEvtInfo.isValid()){
         *genHEPMCweight = genEvtInfo->weight();
-        if (*genHEPMCweight==1. && lheHandler->getLHEOriginalWeight()!=1.) *genHEPMCweight = lheHandler->getLHEOriginalWeight();
+        if (*genHEPMCweight==1.) *genHEPMCweight = lheHandler->getLHEOriginalWeight();
       }
       else *genHEPMCweight = lheHandler->getLHEOriginalWeight(); // Default was also 1, so if !genEvtInfo.isValid(), the statement still passes
       *genHEPMCweight_2016 = *genHEPMCweight; // lheHandler_NNPDF30_NLO->getLHEOriginalWeight() should give the same value

--- a/src/GenMaker.cc
+++ b/src/GenMaker.cc
@@ -313,7 +313,10 @@ void GenMaker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       lheHandler_NNPDF30_NLO->setHandle(&LHEEventInfo);
       lheHandler_NNPDF30_NLO->extract();
 
-      if (genEvtInfo.isValid()) *genHEPMCweight = genEvtInfo->weight();
+      if (genEvtInfo.isValid()){
+        *genHEPMCweight = genEvtInfo->weight();
+        if (*genHEPMCweight==1. && lheHandler->getLHEOriginalWeight()!=1.) *genHEPMCweight = lheHandler->getLHEOriginalWeight();
+      }
       else *genHEPMCweight = lheHandler->getLHEOriginalWeight(); // Default was also 1, so if !genEvtInfo.isValid(), the statement still passes
       *genHEPMCweight_2016 = *genHEPMCweight; // lheHandler_NNPDF30_NLO->getLHEOriginalWeight() should give the same value
       *genHEPMCweight *= lheHandler->getWeightRescale();


### PR DESCRIPTION
- Address the issue with SingleTop samples with NNPDF 3.1 nf4 PDFs (unexpected ordering of weights)
- Some 2016 samples have inconsistent event weights: If weight from GenProductInfo is 1 and LHEInfoProduct exists, pick weight from LHEInfoProduct. This only affects a handful of samples, where |wgt| is constant but negative weight information gets lost. This issue was fixed later in 2016 and no longer exists in 2017 or '18.